### PR TITLE
Enable collection synchronization

### DIFF
--- a/source/InPlaceEditBoxDemo/Behaviours/TreeViewItemBehaviour.cs
+++ b/source/InPlaceEditBoxDemo/Behaviours/TreeViewItemBehaviour.cs
@@ -1,5 +1,6 @@
 ﻿namespace InPlaceEditBoxDemo.Behaviours
 {
+    using System.ComponentModel;
     using System.Windows;
     using System.Windows.Controls;
 
@@ -59,6 +60,10 @@
         #region methods
         private static void OnIsBroughtIntoViewWhenSelectedChanged(DependencyObject depObj, DependencyPropertyChangedEventArgs e)
         {
+            // do not implement interaction logic for WPF Design-Time
+            if (DesignerProperties.GetIsInDesignMode(new System.Windows.DependencyObject()))
+                return;
+
             TreeViewItem item = depObj as TreeViewItem;
             if (item == null)
                 return;

--- a/source/InPlaceEditBoxDemo/Behaviours/TreeViewSelectionChangedBehavior.cs
+++ b/source/InPlaceEditBoxDemo/Behaviours/TreeViewSelectionChangedBehavior.cs
@@ -1,5 +1,6 @@
 ﻿namespace InPlaceEditBoxDemo.Behaviours
 {
+    using System.ComponentModel;
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Input;
@@ -51,6 +52,10 @@
         /// <param name="e"></param>
         private static void OnSelectionChangedCommandChange(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
+            // do not implement interaction logic for WPF Design-Time
+            if (DesignerProperties.GetIsInDesignMode(new System.Windows.DependencyObject()))
+                return;
+
             TreeView uiElement = d as TreeView;  // Remove the handler if it exist to avoid memory leaks
 
             if (uiElement != null)

--- a/source/InPlaceEditBoxDemo/Behaviours/TreeViewVirtualItemBehaviour.cs
+++ b/source/InPlaceEditBoxDemo/Behaviours/TreeViewVirtualItemBehaviour.cs
@@ -3,6 +3,7 @@
     using SolutionLib.Interfaces;
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Diagnostics;
     using System.Reflection;
     using System.Windows;
@@ -63,6 +64,10 @@
         {
             try
             {
+                // do not implement interaction logic for WPF Design-Time
+                if (DesignerProperties.GetIsInDesignMode(new System.Windows.DependencyObject()))
+                    return;
+
                 var tree = d as TreeView;
 
                 // Sanity check: Are we looking at the least required data we need?

--- a/source/InPlaceEditBoxDemo/Behaviours/TreeViewVirtualItemBehaviour.cs
+++ b/source/InPlaceEditBoxDemo/Behaviours/TreeViewVirtualItemBehaviour.cs
@@ -94,36 +94,44 @@
                     var newParent = currentParent.ItemContainerGenerator.ContainerFromItem(node) as TreeViewItem;
                     if (newParent == null)
                     {
-                        // if this failed, it's probably because of virtualization, and we will have to do it the hard way.
-                        // this code is influenced by TreeViewItem.ExpandRecursive decompiled code, and the MSDN sample at
-                        // http://code.msdn.microsoft.com/Changing-selection-in-a-6a6242c8/sourcecode?fileId=18862&pathId=753647475
-                        // see also the question at http://stackoverflow.com/q/183636/46635
-                        currentParent.ApplyTemplate();
-                        var itemsPresenter = (ItemsPresenter)currentParent.Template.FindName("ItemsHost", currentParent);
-                        if (itemsPresenter != null)
-                            itemsPresenter.ApplyTemplate();
-                        else
-                            currentParent.UpdateLayout();
-
-                        var virtualizingPanel = GetItemsHost(currentParent) as VirtualizingPanel;
-
-                        CallEnsureGenerator(virtualizingPanel);
-                        var index = currentParent.Items.IndexOf(node);
-                        if (index < 0)
+                        try
                         {
-                            // This is raised when the item in the path array is not part of the tree collection
-                            // This can be tricky, because Binding an ObservableDictionary to the treeview will
-                            // require that we need an array of KeyValuePairs<K,T>[] here :-(
+                            // if this failed, it's probably because of virtualization, and we will have to do it the hard way.
+                            // this code is influenced by TreeViewItem.ExpandRecursive decompiled code, and the MSDN sample at
+                            // http://code.msdn.microsoft.com/Changing-selection-in-a-6a6242c8/sourcecode?fileId=18862&pathId=753647475
+                            // see also the question at http://stackoverflow.com/q/183636/46635
+                            currentParent.ApplyTemplate();
+                            var itemsPresenter = (ItemsPresenter)currentParent.Template.FindName("ItemsHost", currentParent);
+                            if (itemsPresenter != null)
+                                itemsPresenter.ApplyTemplate();
+                            else
+                                currentParent.UpdateLayout();
+
+                            var virtualizingPanel = GetItemsHost(currentParent) as VirtualizingPanel;
+
+                            CallEnsureGenerator(virtualizingPanel);
+                            var index = currentParent.Items.IndexOf(node);
+                            if (index < 0)
+                            {
+                                // This is raised when the item in the path array is not part of the tree collection
+                                // This can be tricky, because Binding an ObservableDictionary to the treeview will
+                                // require that we need an array of KeyValuePairs<K,T>[] here :-(
 #if DEBUG
                             System.Console.WriteLine("Node '" + node + "' cannot be fount in container");
                             ////                    throw new InvalidOperationException("Node '" + node + "' cannot be fount in container");
 #else
-                        // Use your favourite logger here since the exception will otherwise kill the appliaction
-                        System.Console.WriteLine("Node '" + node + "' cannot be fount in container");
+                                // Use your favourite logger here since the exception will otherwise kill the appliaction
+                                System.Console.WriteLine("Node '" + node + "' cannot be fount in container");
 #endif
+                            }
+                            virtualizingPanel.BringIndexIntoViewPublic(index);
+
+                            newParent = currentParent.ItemContainerGenerator.ContainerFromIndex(index) as TreeViewItem;
                         }
-                        virtualizingPanel.BringIndexIntoViewPublic(index);
-                        newParent = currentParent.ItemContainerGenerator.ContainerFromIndex(index) as TreeViewItem;
+                        catch
+                        {
+                            return;
+                        }
                     }
 
                     if (newParent == null)

--- a/source/InPlaceEditBoxDemo/MainWindow.xaml
+++ b/source/InPlaceEditBoxDemo/MainWindow.xaml
@@ -184,6 +184,9 @@
             
                   VirtualizingStackPanel.IsVirtualizing="True"
                   VirtualizingStackPanel.VirtualizationMode="Standard"
+                  VirtualizingStackPanel.CacheLengthUnit="Page"
+                  VirtualizingStackPanel.CacheLength="0,4"
+                  
                   Style="{StaticResource TreeViewStyle}"
                   ItemTemplateSelector="{StaticResource TreeItemSelector}"
                   behav:TreeViewSelectionChangedBehavior.ChangedCommand="{Binding Solution.SelectionChangedCommand}"

--- a/source/InPlaceEditBoxDemo/Properties/AssemblyInfo.cs
+++ b/source/InPlaceEditBoxDemo/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/source/InplaceEditBoxLib/Properties/AssemblyInfo.cs
+++ b/source/InplaceEditBoxLib/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.3")]
-[assembly: AssemblyFileVersion("1.0.0.3")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]
 
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None, // where theme specific resource dictionaries are located

--- a/source/InplaceEditBoxLib/Views/EditBox.xaml.cs
+++ b/source/InplaceEditBoxLib/Views/EditBox.xaml.cs
@@ -1,6 +1,7 @@
 namespace InplaceEditBoxLib.Views
 {
     using System;
+    using System.ComponentModel;
     using System.Diagnostics;
     using System.Windows;
     using System.Windows.Controls;
@@ -211,6 +212,10 @@ namespace InplaceEditBoxLib.Views
         public EditBox()
         {
             _TextBox = null;
+
+            // do not implement interaction logic for WPF Design-Time
+            if (DesignerProperties.GetIsInDesignMode(new System.Windows.DependencyObject()))
+                return;
 
             this.DataContextChanged += this.OnDataContextChanged;
 


### PR DESCRIPTION
Added queries to design time properties to make sure WPF Designer does not crash when displaying the EditBox in other XAML portions.